### PR TITLE
Experimental publish

### DIFF
--- a/experimental-release.mjs
+++ b/experimental-release.mjs
@@ -1,0 +1,100 @@
+import childProcess from 'child_process'
+import fs from 'fs'
+import path from 'path'
+
+const dir = new URL('.', import.meta.url).pathname
+const rev = run('git rev-parse --short=9 HEAD'.split(' ')).trim()
+const date = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+// Inspired by reacts experimental versioning nomenclature.
+const version = `0.0.0-experimental-${rev}-${date}`
+
+const allPkgs = fs.readdirSync(path.join(dir, 'packages'))
+const pkgDirs = new Map()
+
+// Map directory names to package names
+for (const pkg of allPkgs) {
+  const jsonPath = path.join(dir, 'packages', pkg, 'package.json')
+  const json = JSON.parse(fs.readFileSync(jsonPath))
+  pkgDirs.set(json.name, pkg)
+}
+
+// Collect local dependencies of a package
+const pkgs = process.argv[2] === 'all' ? allPkgs : Array.from(new Set(process.argv.slice(2).map(localDepsOf).flat()))
+if (pkgs.length < 1) throw new Error('You must provide a package as a first argument')
+console.log("I'll do release", version, 'of:', pkgs.join(', '))
+
+// Modify package.json to set a version and depend on correct version
+for (const pkg of pkgs) {
+  const jsonPath = path.join(dir, 'packages', pkgDirs.get(pkg), 'package.json')
+  // If backup exists, then previous run probably crashed. Restore it first.
+  if (fs.existsSync(jsonPath + '.backup')) {
+    fs.copyFileSync(jsonPath + '.backup', jsonPath)
+  }
+  fs.copyFileSync(jsonPath, jsonPath + '.backup')
+
+  const json = JSON.parse(fs.readFileSync(jsonPath))
+  json.version = version
+  for (const key of Object.keys(json.dependencies)) {
+    if (pkgDirs.has(key)) {
+      json.dependencies[key] = version
+    }
+  }
+
+  fs.writeFileSync(jsonPath, JSON.stringify(json, null, 2))
+}
+
+// Create tarballs. I do this instead of direct release to avoid release in case
+// of errors.
+for (const pkg of pkgs) {
+  console.log('Running yarn pack on', pkg)
+  run(['yarn', 'pack', '--filename', 'experimental.tgz'], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    cwd: path.join(dir, 'packages', pkgDirs.get(pkg)),
+  })
+}
+
+// Do the publish
+for (const pkg of pkgs) {
+  console.log('Publishing', pkg)
+  run(['npm', 'publish', 'experimental.tgz', '--tag', 'experimental'], {
+    stdio: ['ignore', 'inherit', 'inherit'],
+    cwd: path.join(dir, 'packages', pkgDirs.get(pkg)),
+  })
+}
+
+// Cleanup - restore package.json backups, remove backups, remove tarballs
+for (const pkg of pkgs) {
+  const jsonPath = path.join(dir, 'packages', pkgDirs.get(pkg), 'package.json')
+  fs.copyFileSync(jsonPath + '.backup', jsonPath)
+  fs.rmSync(jsonPath + '.backup')
+  fs.rmSync(path.join(dir, 'packages', pkgDirs.get(pkg), 'experimental.tgz'))
+}
+
+// Done.
+
+function run(args, opts) {
+  const res = childProcess.spawnSync(args[0], args.slice(1), {
+    stdio: ['ignore', 'pipe', 'inherit'],
+    encoding: 'utf-8',
+    env: process.env,
+    ...opts,
+  })
+  if (res.status !== 0) throw new Error(args[0] + ' exited with non-zero code ' + res.status)
+  return res.stdout
+}
+
+function localDepsOf(pkg) {
+  const pkgDir = pkgDirs.get(pkg)
+  if (!pkgDir) return []
+  const jsonPath = path.join(dir, 'packages', pkgDir, 'package.json')
+  const json = JSON.parse(fs.readFileSync(jsonPath))
+
+  let list = []
+  for (const key of Object.keys(json.dependencies)) {
+    if (pkgDirs.has(key)) {
+      list = list.concat(localDepsOf(key))
+    }
+  }
+  list.push(pkg)
+  return list
+}


### PR DESCRIPTION
This PR adds a script in root folder (since there is no scripts folder) to do a experimental npm release. This is useful in case we want to try changes before they land in main branch.

Usage example: `node experimental-publish.js @opendesign/octopus-fig`

What it does should be self-explanatory from comments, but in a nutshell it creates a release for a given package and all its dependencies while making sure that the versions are declared correctly. In the above example it releases: `octopus-fig, figma-parser and common`. 

Version naming is inspired by react - that is, it is `0.0.0` to not give false sense of any stability, includes the word experimental, git hash and date. There is probably some tool which already does this but I am not aware of it and this took about 30 minutes and solved a problem I had of not being to reasonably try octopus-fig changes in ODF. And since I think that this will be recurring need in the future I figured I would make it a tool and create PR for it :slightly_smiling_face: 

One possible improvement would be to check for existing npm releases and skip if it already exists. This would happen if you ran octopus-fig release and then later figured out that you need to release xd too from same commit. But we can add that once it happens.

For a version released in this way see octopus-fig: [npm](https://www.npmjs.com/package/@opendesign/octopus-fig/v/0.0.0-experimental-addead5d9-20221203?activeTab=versions), [unpkg](https://unpkg.com/@opendesign/octopus-fig@0.0.0-experimental-addead5d9-20221203/), which was released from [isbl/experimental-publish](https://github.com/opendesigndev/octopus/tree/isbl/experimental-publish) branch. This PR is a cherry-pick from there to be able to merge into main directly.

*Sidenote:* originally, I wanted to just release everything, but currently there are TS errors preventing that from happening. At least in the figma branch.