### PR TITLE
Switch to opendesign/psd-ts

### DIFF
--- a/packages/octopus-psd/package.json
+++ b/packages/octopus-psd/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@avocode/psd-parser": "0.8.4",
+    "@opendesign/psd-ts": "0.0.0-experimental-bdd7ebbc",
     "@opendesign/manifest-ts": "3.0.0-alpha.38",
     "@opendesign/octopus-common": "3.0.0-rc.27",
     "@opendesign/octopus-ts": "3.0.0-alpha.38",

--- a/packages/octopus-psd/src/entities/source/source-effect-fill.ts
+++ b/packages/octopus-psd/src/entities/source/source-effect-fill.ts
@@ -1,5 +1,5 @@
 import { firstCallMemo } from '@opendesign/octopus-common/dist/decorators/first-call-memo.js'
-import { DescriptorValueType, UnitFloatType } from '@webtoon/psd'
+import { DescriptorValueType, UnitFloatType } from '@opendesign/psd-ts'
 
 import { getUnitRatioFor, getColor } from '../../utils/source.js'
 import { SourceEffectBase } from './source-effect-base.js'

--- a/packages/octopus-psd/src/services/readers/psd-file-reader.ts
+++ b/packages/octopus-psd/src/services/readers/psd-file-reader.ts
@@ -5,7 +5,7 @@ import { scan } from '@jimp/utils'
 import { asNumber } from '@opendesign/octopus-common/dist/utils/as.js'
 import { benchmarkAsync } from '@opendesign/octopus-common/dist/utils/benchmark-node.js'
 import { displayPerf } from '@opendesign/octopus-common/dist/utils/console.js'
-import Psd, { AliKey } from '@webtoon/psd'
+import Psd, { AliKey } from '@opendesign/psd-ts'
 import chalk from 'chalk'
 import sizeOf from 'image-size'
 import Jimp from 'jimp'
@@ -18,7 +18,7 @@ import { getRawData } from '../../utils/raw.js'
 import { logger } from '../instances/logger.js'
 
 import type { SourceImage } from '../../entities/source/source-design.js'
-import type { NodeChild, Layer } from '@webtoon/psd'
+import type { NodeChild, Layer } from '@opendesign/psd-ts'
 
 type BuffImage = {
   buff: Uint8ClampedArray | Uint8Array

--- a/packages/octopus-psd/src/typings/raw/additionalProperty.ts
+++ b/packages/octopus-psd/src/typings/raw/additionalProperty.ts
@@ -5,7 +5,7 @@ import type {
   AdditionalLayerInfo,
   AliKey,
   TypeToolObjectSettingAliBlock,
-} from '@webtoon/psd/dist/interfaces/'
+} from '@opendesign/psd-ts/dist/interfaces/'
 
 export type DescriptorValuePropertyClass = {
   name: string

--- a/packages/octopus-psd/src/typings/raw/component.ts
+++ b/packages/octopus-psd/src/typings/raw/component.ts
@@ -1,5 +1,5 @@
 import type { LayerProperties, NodeChildWithProps } from './layer'
-import type Psd from '@webtoon/psd'
+import type Psd from '@opendesign/psd-ts'
 
 export type ParsedPsd = Psd & { children: NodeChildWithProps[] } & {
   parsedProperties: LayerProperties

--- a/packages/octopus-psd/src/typings/raw/effects.ts
+++ b/packages/octopus-psd/src/typings/raw/effects.ts
@@ -1,5 +1,5 @@
 import type { RawColor as RawColor } from './shared'
-import type { UnitFloatDescriptorValue } from '@webtoon/psd/dist/interfaces'
+import type { UnitFloatDescriptorValue } from '@opendesign/psd-ts/dist/interfaces'
 
 export type RawShapeTransparency = {
   Opct: number

--- a/packages/octopus-psd/src/typings/raw/layer.ts
+++ b/packages/octopus-psd/src/typings/raw/layer.ts
@@ -4,7 +4,7 @@ import type { RawShapeStrokeStyle, VectorMaskSetting } from './layer-shape'
 import type { RawTextProperties } from './layer-text'
 import type { VectorOriginationData } from './path-component'
 import type { RawColor, RawBounds } from './shared'
-import type { Group, Layer } from '@webtoon/psd'
+import type { Group, Layer } from '@opendesign/psd-ts'
 
 export type RawLayerCommon = {
   isArtboard: boolean

--- a/packages/octopus-psd/src/utils/convert.ts
+++ b/packages/octopus-psd/src/utils/convert.ts
@@ -1,6 +1,6 @@
 import { asFiniteNumber } from '@opendesign/octopus-common/dist/utils/as.js'
 import { round } from '@opendesign/octopus-common/dist/utils/math.js'
-import { UnitFloatType } from '@webtoon/psd'
+import { UnitFloatType } from '@opendesign/psd-ts'
 
 import { DEFAULTS } from './defaults.js'
 

--- a/packages/octopus-psd/src/utils/raw.ts
+++ b/packages/octopus-psd/src/utils/raw.ts
@@ -1,11 +1,11 @@
 import { asArray } from '@opendesign/octopus-common/dist/utils/as.js'
-import { DescriptorValueType, AliKey } from '@webtoon/psd'
+import { DescriptorValueType, AliKey } from '@opendesign/psd-ts'
 
 import { DEFAULTS } from './defaults.js'
 
 import type { DescriptorValueTreeNode, DescriptorValueTree, NodeChildWithProps, ParsedPsd } from '../typings/raw'
-import type Psd from '@webtoon/psd'
-import type { NodeChild, AdditionalLayerInfo } from '@webtoon/psd'
+import type Psd from '@opendesign/psd-ts'
+import type { NodeChild, AdditionalLayerInfo } from '@opendesign/psd-ts'
 import type {
   AliasDescriptorValue,
   DescriptorDescriptorValue,
@@ -17,7 +17,7 @@ import type {
   ObjectArrayDescriptorValue,
   ListDescriptorValue,
   UnitFloatDescriptorValue,
-} from '@webtoon/psd/dist/interfaces/'
+} from '@opendesign/psd-ts/dist/interfaces/'
 
 export function parseDescriptorItems(items?: Map<string, DescriptorValue>): DescriptorValueTree {
   if (!items) {

--- a/packages/octopus-psd/src/utils/source.ts
+++ b/packages/octopus-psd/src/utils/source.ts
@@ -1,5 +1,5 @@
 import { asFiniteNumber, asNumber } from '@opendesign/octopus-common/dist/utils/as.js'
-import { AliKey, Layer } from '@webtoon/psd'
+import { AliKey, Layer } from '@opendesign/psd-ts'
 import intersection from 'lodash/intersection.js'
 
 import { PSDFileReader } from '../services/readers/psd-file-reader.js'
@@ -14,8 +14,8 @@ import type {
   NodeChildWithProps,
 } from '../typings/raw'
 import type { SourceBounds, SourceColor, SourceMatrix, SourcePointXY, SourceRadiiCorners } from '../typings/source.js'
-import type { AdditionalLayerInfo, NodeChild } from '@webtoon/psd'
-import type { AdditionalLayerProperties } from '@webtoon/psd/dist/sections'
+import type { AdditionalLayerInfo, NodeChild } from '@opendesign/psd-ts'
+import type { AdditionalLayerProperties } from '@opendesign/psd-ts/dist/sections'
 
 export function isArtboard(raw: NodeChild) {
   return Boolean(raw?.additionalProperties?.[AliKey.ArtboardData])


### PR DESCRIPTION
had to do this change to be actually able to use octopus-psd with our webtoon fork of psd parser