### PR TITLE
fix files in prepareRelease

### DIFF
--- a/packages/octopus-ai/prepare-release.mjs
+++ b/packages/octopus-ai/prepare-release.mjs
@@ -7,6 +7,9 @@ const RELEASE_DIR = './release'
 
 const RELEASE_PROPS = {
   files: [
+    // types
+    'index-node.d.ts',
+    'index-web.d.ts',
     // es, node
     'index.mjs',
     'index.d.mts',

--- a/packages/octopus-fig/prepare-release.mjs
+++ b/packages/octopus-fig/prepare-release.mjs
@@ -7,6 +7,9 @@ const RELEASE_DIR = './release'
 
 const RELEASE_PROPS = {
   files: [
+    // types
+    'index-node.d.ts',
+    'index-web.d.ts',
     // es, node
     'index.mjs',
     'index.d.mts',

--- a/packages/octopus-psd/package.json
+++ b/packages/octopus-psd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opendesign/octopus-psd",
-  "version": "3.1.0-rc.7",
+  "version": "3.1.0-rc.12",
   "description": "Octopus PSD converter, converts .psd files to Octopus 3+ format.",
   "license": "Apache-2.0",
   "scripts": {

--- a/packages/octopus-psd/prepare-release.mjs
+++ b/packages/octopus-psd/prepare-release.mjs
@@ -7,6 +7,10 @@ const RELEASE_DIR = './release'
 
 const RELEASE_PROPS = {
   files: [
+    // types
+    'index-node.d.ts',
+    'index-web.d.ts',
+
     // es, node
     'index.mjs',
     'index.d.mts',

--- a/packages/octopus-xd/prepare-release.mjs
+++ b/packages/octopus-xd/prepare-release.mjs
@@ -7,6 +7,9 @@ const RELEASE_DIR = './release'
 
 const RELEASE_PROPS = {
   files: [
+    // types
+    'index-node.d.ts',
+    'index-web.d.ts',
     // es, node
     'index.mjs',
     'index.d.mts',


### PR DESCRIPTION
 files in package.son  dictate which files should be published and index-web.d.ts and index-node.d.ts were missing. This did not occur to me when we tested this with tarball and not direction to release dir. When we removed the tarball I have tested the packages only through yarn link