### PR TITLE
Fix yarn clean - missing rimraf

### DIFF
--- a/packages/figma-parser-s3-plugin/package.json
+++ b/packages/figma-parser-s3-plugin/package.json
@@ -18,14 +18,15 @@
     "dotenv": "16.0.0",
     "lodash": "^4.17.21",
     "pino": "^6.7.0",
-    "pino-pretty": "^4.3.0"
+    "pino-pretty": "^4.3.0",
+    "rimraf": "^3.0.2"
   },
   "devDependencies": {
     "@types/node": "*",
-    "ts-node": "10.5.0",
-    "typescript": "4.6.4",
     "@types/pino-pretty": "4.7.5",
-    "@types/pino-std-serializers": "2.4.1"
+    "@types/pino-std-serializers": "2.4.1",
+    "ts-node": "10.5.0",
+    "typescript": "4.6.4"
   },
   "files": [
     "lib/src"

--- a/packages/figma-parser/package.json
+++ b/packages/figma-parser/package.json
@@ -23,14 +23,15 @@
     "lodash": "^4.17.21",
     "pino": "^6.7.0",
     "pino-pretty": "^4.3.0",
+    "rimraf": "^3.0.2",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@types/chalk": "^2.2.0",
     "@types/node": "*",
-    "@types/pino-std-serializers": "2.4.1",
     "@types/pino-pretty": "4.7.5",
+    "@types/pino-std-serializers": "2.4.1",
     "chalk": "^4.1.2",
     "jest": "^27.3.1",
     "ts-node": "10.5.0",


### PR DESCRIPTION
Wanted to run `yarn clean-init` locally in the root of repo and it failed due to missing rimraf